### PR TITLE
いいねカウントの実装

### DIFF
--- a/app/assets/stylesheets/teams.scss
+++ b/app/assets/stylesheets/teams.scss
@@ -117,3 +117,11 @@
   }
 }
 
+.star_counter {
+  margin-top: 15px;
+
+  span {
+    color: $primary-color;
+    font-weight: bold;
+  }
+}

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,27 +1,34 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_like
+  before_action :like_counts
 
   def show
     like_status = current_user.has_liked?(@team)
-    render json: { hasLiked: like_status }
+
+    render json: { hasLiked: like_status, likeCount: like_counts }.to_json
   end
 
   def create
     @team.likes.create!(user_id: current_user.id)
-    render json: { status: 'ok' }
+
+    render json: { status: 'ok', likeCount: like_counts }.to_json
   end
 
   def destroy
     like = @team.likes.find_by!(user_id: current_user.id)
     like.destroy!
 
-    render json: { status: 'ok' }
+    render json: { status: 'ok', likeCount: like_counts }.to_json
   end
 
   private
 
   def set_like
     @team = Team.find(params[:team_id])
+  end
+
+  def like_counts
+    @like_count = @team.likes.count
   end
 end

--- a/app/javascript/modules/handle_like.js
+++ b/app/javascript/modules/handle_like.js
@@ -1,30 +1,38 @@
 import $ from 'jquery'
 import axios from 'modules/axios'
 
+const likeCountCalculation = (starCount) => {
+  $('.star_counter > span').append(
+    `${starCount}人`
+  )
+}
+
 const elementInActiveStarLikeGet = () => {
   $('.in-active-star').each(function (index, element) {
-    let likeData = $(element).data()
-    let getId = likeData.teamId
-    axios.get(`/teams/${getId}/like`)
+    const likeData = $(element).data()
+    const teamId = likeData.teamId
+    axios.get(`/teams/${teamId}/like`)
       .then((response) => {
         const inActiveStatus = response.data.hasLiked
         if ( inActiveStatus === false ) {
           $(element).removeClass('hidden')
-        } 
+        }
+        const starCount = response.data.likeCount
+        likeCountCalculation(starCount)
       })
   })
 }
 
 const elementActiveStarLikeGet = () => {
   $('.active-star').each(function (index, element) {
-    let likeData = $(element).data()
-    let getId = likeData.teamId
-    axios.get(`/teams/${getId}/like`)
+    const likeData = $(element).data()
+    const teamId = likeData.teamId
+    axios.get(`/teams/${teamId}/like`)
       .then((response) => {
         const activeStatus = response.data.hasLiked
         if ( activeStatus === true) {
           $(element).removeClass('hidden')
-        } 
+        }
       })
   })
 }
@@ -40,6 +48,9 @@ const listenInActiveStarLikeEvent = () => {
         $(`#in-active-star${teamId}`).addClass('hidden');
         $(`#active-star${teamId}`).removeClass('hidden');
       }
+      const starCount = response.data.likeCount
+      $('.star_counter > span').html('')
+      likeCountCalculation(starCount)
     })
     .catch((e) => {
       window.alert('Error')
@@ -59,6 +70,9 @@ const listenActiveStarLikeEvent = () => {
         $(`#active-star${teamId}`).addClass('hidden');
         $(`#in-active-star${teamId}`).removeClass('hidden');
       }
+      const starCount = response.data.likeCount
+      $('.star_counter > span').html('')
+      likeCountCalculation(starCount)
     })
     .catch((e) => {
       window.alert('Error')

--- a/app/views/teams/show.html.haml
+++ b/app/views/teams/show.html.haml
@@ -45,10 +45,10 @@
         %p= @team.period.name
 
       .star
-        .star_count
-          現在２人がお気に入りしています。
-        .star_status
-          いいねボタンを配置
+        .star_counter
+          現在
+          %span
+          がいいねをしています。
   - if user_signed_in?
     - unless current_user.has_made?(@team)
       = form_with(url: team_team_users_path(@team), local: true) do |f|


### PR DESCRIPTION
## What
Fixes #16  
- いいねの数をjson形式で返せるようにAPIにlike_countを追加した。
- いいねの数を表示させたいところをテンプレートに記述した。
- Ajaxでいいねの数を取得できるようにした。

## Why
いいねされている数をわかるようにするため。