### PR TITLE
SNS認証のときは自動でパスワードが生成される

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:google_oauth2]
 
+  PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'は英字と数字の両方を含めて設定してください'
+
   delegate :birthday, :age, :gender, :bio, to: :profile, allow_nil: true
 
   def self.from_omniauth(auth)
@@ -34,7 +37,7 @@ class User < ApplicationRecord
 
     if user.persisted?
       sns.user = user
-      sns.save
+      sns.save(validate: false)
     end
     { user: user, sns: sns }
   end


### PR DESCRIPTION
## What
- 手打ち入力で新規登録を行う時は英数字で6文字以上のバリデーションをかける
- SNS認証のときはパスワード入力が必要ない

## Why
ユーザーの新規登録を容易にするため